### PR TITLE
Improvement/deploy script

### DIFF
--- a/frontend/uploadDistToS3.sh
+++ b/frontend/uploadDistToS3.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+FILES=()
+
+DEFAULT_TTL=100
+DEBUG=false
+
+# get command line arguments
+for i in "$@"
+do
+case $i in
+    -b=*|--bucket=*)
+    BUCKET="${i#*=}"
+    shift # past argument=value
+    ;;
+    -t=*|--ttl=*)
+    TTL="${i#*=}"
+    shift # past argument=value
+    ;;
+    -ti=*|--ttl-index=*)
+    TTLINDEX="${i#*=}"
+    shift
+    ;;
+    -d=*|--debug=*)
+    DEBUG=true
+    shift
+    ;;
+    --default)
+    DEFAULT=YES
+    shift # past argument with no value
+    ;;
+    *)
+    FILES[$ind]=$i
+    ind=$((ind+1))
+          # unknown option
+    ;;
+esac
+done
+
+if [ -z $TTLINDEX ]; then
+  TTLINDEX=$TTL
+fi
+if [ -z $TTLINDEX ]; then
+  TTL=$DEFAULT_TTL
+  TTLINDEX=$DEFAULT_TTL
+fi
+
+# add in the script folder, no ttl necessary
+aws s3 cp ./dist/scripts/ s3://$BUCKET/scripts/
+
+# add in the index files with their index specific TTL
+aws s3 cp ./dist/index.html s3://$BUCKET/ --cache-control $TTLINDEX
+
+
+if $DEBUG; then
+  # use default ttl
+  #aws s3 cp ./dist/ s3://$BUCKET/ --cache-control $DEFAULT_TTL
+  echo ayy
+else
+  echo bayy
+  # dont use any ttl
+  #aws s3 cp ./dist/ s3://$BUCKET/
+fi

--- a/frontend/uploadDistToS3.sh
+++ b/frontend/uploadDistToS3.sh
@@ -14,12 +14,8 @@ case $i in
     shift # past argument=value
     ;;
     -t=*|--ttl=*)
-    TTL="${i#*=}"
-    shift # past argument=value
-    ;;
-    -ti=*|--ttl-index=*)
     TTLINDEX="${i#*=}"
-    shift
+    shift # past argument=value
     ;;
     -d=*|--debug=*)
     DEBUG=true
@@ -38,26 +34,25 @@ esac
 done
 
 if [ -z $TTLINDEX ]; then
-  TTLINDEX=$TTL
-fi
-if [ -z $TTLINDEX ]; then
-  TTL=$DEFAULT_TTL
   TTLINDEX=$DEFAULT_TTL
 fi
 
-# add in the script folder, no ttl necessary
-aws s3 cp ./dist/scripts/ s3://$BUCKET/scripts/
+
+# # add in the script folder, no ttl necessary
+aws s3 cp ./dist/scripts/ s3://$BUCKET/scripts/ --recursive
 
 # add in the index files with their index specific TTL
 aws s3 cp ./dist/index.html s3://$BUCKET/ --cache-control $TTLINDEX
+# uncomment these if you want to have extra folders for support, and about
+#aws s3 cp ./dist/support/ s3://$BUCKET/support --recursive --cache-control $TTLINDEX
+#aws s3 cp ./dist/about/ s3://$BUCKET/about --recursive --cache-control $TTLINDEX
 
 
+# add in all the other files
 if $DEBUG; then
   # use default ttl
-  #aws s3 cp ./dist/ s3://$BUCKET/ --cache-control $DEFAULT_TTL
-  echo ayy
+  aws s3 cp ./dist/ s3://$BUCKET --recursive --exclude "index.html" --exclude "scripts/*" --exclude "about/*" --exclude "support/*" --cache-control $DEFAULT_TTL
 else
-  echo bayy
   # dont use any ttl
-  #aws s3 cp ./dist/ s3://$BUCKET/
+  aws s3 cp ./dist/ s3://$BUCKET --recursive --exclude "index.html" --exclude "scripts/*" --exclude "about/*" --exclude "support/*"
 fi


### PR DESCRIPTION
closes #16 
adds a simple script that uploads all index files with a TTL, and uploads everything else inside of dist without a TTL, and puts the files in proper folders.